### PR TITLE
Change link target user from "Door43" to "unfoldingWord"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ venv/
 
 # mkdocs documentation
 /site
+
+# Scripts
+setENVs.sh

--- a/converters/md2html_converter.py
+++ b/converters/md2html_converter.py
@@ -366,7 +366,7 @@ class Md2HtmlConverter(Converter):
                     write_file(os.path.join(self.debug_dir, base_name_part+'.2.html'), html)
 
                 if '_index' in filepath:
-                    html = self.fix_markdown_urls(html)
+                    html = self.fix_lexicon_markdown_urls(html)
                     if prefix and debug_mode_flag:
                         write_file(os.path.join(self.debug_dir, base_name_part+'.3.html'), html)
 
@@ -400,12 +400,12 @@ class Md2HtmlConverter(Converter):
     # end of Md2HtmlConverter.convert_lexicon()
 
 
-    def fix_markdown_urls(self, content):
+    def fix_lexicon_markdown_urls(self, content):
         """
         Change lexicon links that point to .md URL to instead point to a default page
             with the xxx.md link added
         """
-        self.log.info("Md2HtmlConverter.fix_markdown_urls()…")
+        self.log.info("Md2HtmlConverter.fix_lexicon_markdown_urls()…")
         if 'href="https://git.door43.org/' not in content:
             self.log.error(f"Md2HtmlConverter.write_lexicon_view_entry_file() has unexpected links: {content}")
 

--- a/converters/tsv2html_converter.py
+++ b/converters/tsv2html_converter.py
@@ -182,8 +182,8 @@ class Tsv2HtmlConverter(Converter):
     def fix_links(self, source_text):
         """
         Change links from 'rc://en/ta/man/' and 'rc://en/tw/dict/'
-            to https://git.door43.org/Door43/en_ta/src/master/…
-            and https://git.door43.org/Door43/en_tw/src/master/…
+            to https://git.door43.org/unfoldingWord/en_ta/src/master/…
+            and https://git.door43.org/unfoldingWord/en_tw/src/master/…
         """
         # GlobalSettings.logger.debug(f"fix_links({source_text}) …")
         assert 'QQQQ' not in source_text and 'ZZZZ' not in source_text
@@ -196,12 +196,12 @@ class Tsv2HtmlConverter(Converter):
             # GlobalSettings.logger.debug(f"fix_links found link_contents = '{link_contents}'")
             if link_contents.startswith('rc://en/ta/man/'):
                 link_contents = link_contents[15:] # Remove unwanted prefix
-                #adjusted_link = f'<a href="https://git.door43.org/Door43/en_ta/src/master/{link_contents}/01.md">Door43/en_ta/src/master/{link_contents}/01.md</a>'
-                adjusted_link = f'<a href="https://git.door43.org/Door43/en_ta/src/master/{link_contents}/01.md">translationAcademy:{link_contents}</a>'
+                #adjusted_link = f'<a href="https://git.door43.org/unfoldingWord/en_ta/src/master/{link_contents}/01.md">Door43/en_ta/src/master/{link_contents}/01.md</a>'
+                adjusted_link = f'<a href="https://git.door43.org/unfoldingWord/en_ta/src/master/{link_contents}/01.md">translationAcademy:{link_contents}</a>'
             elif link_contents.startswith('rc://en/tw/dict/'):
                 link_contents = link_contents[16:] # Remove unwanted prefix
-                #adjusted_link = f'<a href="https://git.door43.org/Door43/en_tw/src/master/{link_contents}.md">Door43/en_tw/src/master/{link_contents}.md</a>'
-                adjusted_link = f'<a href="https://git.door43.org/Door43/en_tw/src/master/{link_contents}.md">translationWords:{link_contents}</a>'
+                #adjusted_link = f'<a href="https://git.door43.org/unfoldingWord/en_tw/src/master/{link_contents}.md">Door43/en_tw/src/master/{link_contents}.md</a>'
+                adjusted_link = f'<a href="https://git.door43.org/unfoldingWord/en_tw/src/master/{link_contents}.md">translationWords:{link_contents}</a>'
             else:
                 self.log.error(f"Cannot convert link: '{link_contents.replace('QQQQ','[[').replace('ZZZZ',']]')}'")
                 adjusted_link = link_contents

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ pyyaml==5.1.1
 py-dateutil==2.2
 
 # sqlalchemy is used by manifest
-sqlalchemy==1.3.4
+sqlalchemy==1.3.5
 pymysql==0.9.3
 
 # boto3 is used by aws_tools
-boto3==1.9.170
+boto3==1.9.174
 
 # pyparsing is used by usfm_tools/parseUsfm.py
 pyparsing==2.4.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,11 +11,11 @@ pyyaml==5.1.1
 py-dateutil==2.2
 
 # sqlalchemy is used by manifest
-sqlalchemy==1.3.4
+sqlalchemy==1.3.5
 pymysql==0.9.3
 
 # boto3 is used by aws_tools
-boto3==1.9.170
+boto3==1.9.174
 
 # pyparsing is used by usfm_tools/parseUsfm.py
 pyparsing==2.4.0

--- a/tests/linter_tests/test_markdown_linter.py
+++ b/tests/linter_tests/test_markdown_linter.py
@@ -59,7 +59,7 @@ class TestMarkdownLinter(LinterTestCase):
         commit_data = {
             "repository": {
                 "owner": {
-                    "username": "Door43"
+                    "username": "unfoldingWord"
                 },
                 "name": "en_ta"
             }
@@ -72,9 +72,9 @@ class TestMarkdownLinter(LinterTestCase):
             'identifier': identifier,
             'success': True,
             'warnings': [
-                '<a href="https://git.door43.org/Door43/en_ta/src/master/intro\\finding-answers\\01.md" target="_blank">intro\\finding-answers\\01.md</a> - Line 1: First line in file should be a top level header. See "Text on first line"',
-                '<a href="https://git.door43.org/Door43/en_ta/src/master/intro\\uw-intro\\01.md" target="_blank">intro\\uw-intro\\01.md</a> - Line 1: First line in file should be a top level header. See "Text on first line"',
-                '<a href="https://git.door43.org/Door43/en_ta/src/master/intro\\uw-intro\\01.md" target="_blank">intro\\uw-intro\\01.md</a> - Line 29: Unordered list indentation. ',
+                '<a href="https://git.door43.org/unfoldingWord/en_ta/src/master/intro\\finding-answers\\01.md" target="_blank">intro\\finding-answers\\01.md</a> - Line 1: First line in file should be a top level header. See "Text on first line"',
+                '<a href="https://git.door43.org/unfoldingWord/en_ta/src/master/intro\\uw-intro\\01.md" target="_blank">intro\\uw-intro\\01.md</a> - Line 1: First line in file should be a top level header. See "Text on first line"',
+                '<a href="https://git.door43.org/unfoldingWord/en_ta/src/master/intro\\uw-intro\\01.md" target="_blank">intro\\uw-intro\\01.md</a> - Line 29: Unordered list indentation. ',
             ],
             #'s3_results_key': None
         }

--- a/tests/resources/webhook_post.json
+++ b/tests/resources/webhook_post.json
@@ -43,11 +43,11 @@
       "id": 3068,
       "owner": {
         "id": 613,
-        "login": "Door43",
-        "full_name": "Door43",
+        "login": "unfoldingWord",
+        "full_name": "unfoldingWord",
         "email": "door43@noreply.door43.org",
         "avatar_url": "https://git.door43.org/img/avatar_default.png",
-        "username": "Door43"
+        "username": "unfoldingWord"
       },
       "name": "en_obs",
       "full_name": "Door43/en_obs",
@@ -58,9 +58,9 @@
       "parent": null,
       "mirror": false,
       "size": 2161,
-      "html_url": "https://git.door43.org/Door43/en_obs",
+      "html_url": "https://git.door43.org/unfoldingWord/en_obs",
       "ssh_url": "git@git.door43.org:Door43/en_obs.git",
-      "clone_url": "https://git.door43.org/Door43/en_obs.git",
+      "clone_url": "https://git.door43.org/unfoldingWord/en_obs.git",
       "website": "http://openbiblestories.com",
       "stars_count": 1,
       "forks_count": 8,


### PR DESCRIPTION
This reduces the need for redirects from https://git.door43.org/Door43/… to https://git.door43.org/unfoldingWord/…

Also updates some packages.